### PR TITLE
🚧 proposal patch

### DIFF
--- a/Web3privacynowplatform/scoringmodel/DeFi category prototype.md
+++ b/Web3privacynowplatform/scoringmodel/DeFi category prototype.md
@@ -3,59 +3,60 @@
 [Applied scoring approach](https://mirror.xyz/0x0f1F3DAf416B74DB3DE55Eb4D7513a80F4841073/E9QPx9iKgPXPqEsAN-YklipSRJy9VTBMOLwwEcqqVpU)
 
 **Simplified overview**
-| Project | GitHub | Team | Docs | Audit | Score |
-| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| **Test project** | available & active GitHub / not (25%) | public team / not (25%) | available & not marketing docs / not (25%) | available & up to date third-party audit / not (25%) | total |
-| -> | 25% | 25% | 25% | 25% | from 0% to 100% |
+| Project | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| **Test project** | available & active GitHub / not (25%) | Live or 🚧 (exclusion criteria) | public team / not (25%) | available & not marketing docs / not (25%) | available & up to date third-party audit / not (25%) | total |
+| -> | 25% | 🚧 | 25% | 25% | 25% | from 0% to 100% |
 
 **Note**:
 - persona: non-techie
 - max score: 100% (public GitHub, third-party audit, public Docs, public team)  
 - min score: 0%
 - 🚩 - represents project sunset, empty or inactive Github, marketing docs
+- 🚧 - represents that the project is not live on mainnet, this is an exclusion criteria that forces project score to be 0%
 
 ## DeFi
 ![alt text](https://github.com/Msiusko/web3privacy/blob/main/static-assets/DEFI.png?raw=true)
 | Project  | Description | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | Firn is the first-ever zero-knowledge privacy platform in the _account-based_ model, and introduces pluggable, flexible privacy to Ethereum-based chains. ✨️**ZK** | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Shade](https://shadeprotocol.io)  | Shade Protocol is an array of connected privacy-preserving DeFi applications built on Secret Network  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
-| [Silent protocol](https://www.silentprotocol.org)  | Silent Protocol is the first protocol enabling compliant full-stack privacy for smart contract assets and web3 applications at scale.  | - | TBD | anon | - | - | 0% |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | A MEV Minimization solution to survive the Dark Forest  | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
-| [Sienna Network](https://sienna.network) | Sienna is a privacy-first and cross-chain decentralized finance platform where you can privately swap, lend and convert your tokens into their private equivalent  | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
-| [Elusiv](https://elusiv.io) | Create blockchain privacy solutions that are built for everyday transactions — with the power of scalable ZK infrastructure on Solana ✨️**ZK** | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
-| [Offshift](https://www.offshift.io) | Offshift’s proprietary Shifting mechanism allows users to Shift between our native token, XFT, and a full palette of private synthetics | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 25% |
-| [CAPE](https://www.espressosys.com/product) | Configurable Asset Privacy for Ethereum | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Evanesco](https://evanesco.org) | A financial protocol platform that combines Layer0 network infrastructure with a private computing framework. | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
-| [Dusk Network](https://dusk.network) | Is technology for securities. An open source and secure blockchain (DLT) infrastructure that businesses use to tokenize financial instruments and automate costly processes. | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [Firn Protocol](https://app.firn.cash) | Firn is the first-ever zero-knowledge privacy platform in the _account-based_ model, and introduces pluggable, flexible privacy to Ethereum-based chains. ✨️**ZK** | ([GitHub](https://github.com/firnprotocol)) | live | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Shade](https://shadeprotocol.io)  | Shade Protocol is an array of connected privacy-preserving DeFi applications built on Secret Network  | ([GitHub](https://github.com/securesecrets/shade)) | live | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
+| [Silent protocol](https://www.silentprotocol.org)  | Silent Protocol is the first protocol enabling compliant full-stack privacy for smart contract assets and web3 applications at scale.  | - | 🚧 | anon | - | - | 0% |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | A MEV Minimization solution to survive the Dark Forest  | - | 🚩 | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
+| [Sienna Network](https://sienna.network) | Sienna is a privacy-first and cross-chain decentralized finance platform where you can privately swap, lend and convert your tokens into their private equivalent  | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | 🚧 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
+| [Elusiv](https://elusiv.io) | Create blockchain privacy solutions that are built for everyday transactions — with the power of scalable ZK infrastructure on Solana ✨️**ZK** | ([GitHub](https://github.com/elusiv-privacy)) | live | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
+| [Offshift](https://www.offshift.io) | Offshift’s proprietary Shifting mechanism allows users to Shift between our native token, XFT, and a full palette of private synthetics | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live | ([anon](https://offshift.io/#team)) | - | - | 25% |
+| [CAPE](https://www.espressosys.com/product) | Configurable Asset Privacy for Ethereum | ([GitHub](https://github.com/EspressoSystems/cape)) | 🚧 | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
+| [Evanesco](https://evanesco.org) | A financial protocol platform that combines Layer0 network infrastructure with a private computing framework. | ([GitHub](https://github.com/Evanesco-Labs)) | live | anon | - | - | 25% |
+| [Dusk Network](https://dusk.network) | Is technology for securities. An open source and secure blockchain (DLT) infrastructure that businesses use to tokenize financial instruments and automate costly processes. | ([GitHub](https://github.com/dusk-network)) | 🚧 | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
 | [Manta Pay](https://app.manta.network/dolphin/transact) | MantaPay is coming to Calamari as the first privacy payment solution in the Kusama ecosystem.✨️**ZK**  | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | an interoperable private bridge ✨️**ZK** | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Panther Protocol](https://www.pantherprotocol.io) | is a decentralized privacy metaprotocol enabling confidential, trusted transactions and interoperability with DeFi ✨️**ZK** | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
-| 🚩 **sunset** [zk.money](https://zk.money) | The private DeFi yield aggregator for Ethereum.✨️**ZK** | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | anon | [Docs](https://docs.aztec.network) | - |  25% |
-| [RAILGUN](https://railgun.org) | Private transfers and DeFi infra for Ethereum, Polygon, Binance Smart Chain and Arbitrum.✨️**ZK** | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
-| [Umbra](https://app.umbra.cash) |  As a protocol, Umbra defines a simple set of standards, coupled with a singleton smart contract instance, to enable stealth addresses on Ethereum | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
-| [Light Shield](https://shield.lightprotocol.com) |  private transactions for Solana. | - | mainnet-beta  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | Decentralized Anonymous Payment Systems ✨️**ZK** | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
-| [Diva](https://www.diva.exchange/en/) | Free banking technology for everyone: everyone can join in, everyone can use DIVA.EXCHANGE | ([GitHub](https://github.com/diva-exchange)) | TBD | - | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | the first and only multichain dApp to offer plug-and-play private DeFi (PriFi) across all EVM-compatible chains | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 25% |
-| [BasicSwap](https://basicswapdex.com) | Private Cross-Chain DEX | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
-| [Common](https://common.fi) | Common will be a decentralized exchange that mitigates the Maximal Extractable Value (MEV) problem. | - | coming in 2023 | anon | - | - | 0% |
-| [Sacred](https://sacred.finance) |  multi-chain DeFi Platform offers private Yield Bearing Deposits to DeFi users ✨️**ZK* | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | Ethereum, Polygon | anon | - | - | 25% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | The first dedicated privacy protocol ecosystem that enables on-platform trade between volatile and stable assets | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
-| 🚩 **sunset** [DeFiner](https://definer.org) | Permission-less and configurable decentralized lending protocol with privacy 100% protected ✨️**ZK** | ([GitHub](https://github.com/DeFinerOrg)) | beta | DeFiner | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
-| [Hurricane Protocol](https://hurricane.money) | A fully decentralized protocol offering private transactions on both the Terra & NEAR | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
-| [StealthPay](https://www.stealthpay.cash) | a stealth address protocol for Ethereum.| 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | collection of tools allowing you send & receive SCRT anonymously | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | - | 25% |
-| [Hinkal](https://hinkal.pro) | an easy-to-integrate privacy SDK that helps users anonymize transactions.  | - | mainnet | Polygon | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
-| [Conceal Network](https://conceal.network) | privacy-protected DeFi & encrypted comms | ([GitHub](https://github.com/ConcealNetwork)) | Live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
-| [CIA protocol](https://ciaprotocol.com) | Building the truest form of DeFi with privacy by default. | - | TBD | anon | - | - | 0% |
-| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | Decentralized Multi Chain P2P Order Book | - | - | anon | - | - | 0% |
-| [Seven Seas](https://www.sevenseas.exchange) | No KYC, privacy Focused crypto Exchange | - | - | - | - | - | - | 0% |
-| [NonKYC](https://nonkyc.io) | NonKYC Exchange | - | - | - | - | - | - | 0% |
-| [zkUSD](https://zkusd.money/#Features) | Privacy-Preserving Collateralized Lending & more | 🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
-| [Spiral Finance](https://www.spiralfi.io) | non-custodial privacy solution based on ZK-Sync ERA ✨️**ZK** | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
-| [Fairy](https://fairyswap.finance/swap) | comprehensive DeFi platform for token swaps, lending, NFT trading, collateralization | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
-| [Shade Cash](https://shade.cash) | A decentralized protocol for private transactions on Fantom Opera | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
+| [Webb](https://app.webb.tools/#/tornado) | an interoperable private bridge ✨️**ZK** | ([GitHub](https://github.com/webb-tools)) | 🚧 | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Panther Protocol](https://www.pantherprotocol.io) | is a decentralized privacy metaprotocol enabling confidential, trusted transactions and interoperability with DeFi ✨️**ZK** | ([GitHub](https://github.com/pantherprotocol))  | live | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
+| 🚩 **sunset** [zk.money](https://zk.money) | The private DeFi yield aggregator for Ethereum.✨️**ZK** | ([Docs](https://docs.aztec.network/zk-money/userguide)) | 🚩 | anon | [Docs](https://docs.aztec.network) | - |  25% |
+| [RAILGUN](https://railgun.org) | Private transfers and DeFi infra for Ethereum, Polygon, Binance Smart Chain and Arbitrum.✨️**ZK** | [Github](https://github.com/Railgun-Community) | live | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| [Umbra](https://app.umbra.cash) |  As a protocol, Umbra defines a simple set of standards, coupled with a singleton smart contract instance, to enable stealth addresses on Ethereum | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | live | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
+| [Light Shield](https://shield.lightprotocol.com) |  private transactions for Solana. | - | live | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | Decentralized Anonymous Payment Systems ✨️**ZK** | - | 🚧 | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
+| [Diva](https://www.diva.exchange/en/) | Free banking technology for everyone: everyone can join in, everyone can use DIVA.EXCHANGE | ([GitHub](https://github.com/diva-exchange)) | 🚧 | - | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
+| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | the first and only multichain dApp to offer plug-and-play private DeFi (PriFi) across all EVM-compatible chains | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | 🚩 | anon | - | - | 25% |
+| [BasicSwap](https://basicswapdex.com) | Private Cross-Chain DEX | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | live | ([anon](https://particl.io/)) | - | - | 50% |
+| [Common](https://common.fi) | Common will be a decentralized exchange that mitigates the Maximal Extractable Value (MEV) problem. | - | 🚧 | anon | - | - | 0% |
+| [Sacred](https://sacred.finance) |  multi-chain DeFi Platform offers private Yield Bearing Deposits to DeFi users ✨️**ZK* | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | 🚧 | Ethereum, Polygon | anon | - | - | 25% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | The first dedicated privacy protocol ecosystem that enables on-platform trade between volatile and stable assets | - | 🚩 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
+| 🚩 **sunset** [DeFiner](https://definer.org) | Permission-less and configurable decentralized lending protocol with privacy 100% protected ✨️**ZK** | ([GitHub](https://github.com/DeFinerOrg)) | 🚩 | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
+| [Hurricane Protocol](https://hurricane.money) | A fully decentralized protocol offering private transactions on both the Terra & NEAR | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | 🚧 | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
+| [StealthPay](https://www.stealthpay.cash) | a stealth address protocol for Ethereum.| 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | 🚩 | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | collection of tools allowing you send & receive SCRT anonymously | ([GitHub](https://github.com/TriviumNode)) | 🚧 | anon | - | - | 25% |
+| [Hinkal](https://hinkal.pro) | an easy-to-integrate privacy SDK that helps users anonymize transactions.  | - | live | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
+| [Conceal Network](https://conceal.network) | privacy-protected DeFi & encrypted comms | ([GitHub](https://github.com/ConcealNetwork)) | live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
+| [CIA protocol](https://ciaprotocol.com) | Building the truest form of DeFi with privacy by default. | - | 🚧 | anon | - | - | 0% |
+| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | Decentralized Multi Chain P2P Order Book | - | 🚩 | anon | - | - | 0% |
+| [Seven Seas](https://www.sevenseas.exchange) | No KYC, privacy Focused crypto Exchange | - | 🚧 | - | - | - | 0% |
+| [NonKYC](https://nonkyc.io) | NonKYC Exchange | - | - | 🚧 | - | - | - | 0% |
+| [zkUSD](https://zkusd.money/#Features) | Privacy-Preserving Collateralized Lending & more | 🚩 | 🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
+| [Spiral Finance](https://www.spiralfi.io) | non-custodial privacy solution based on ZK-Sync ERA ✨️**ZK** | - | 🚧 | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| [Fairy](https://fairyswap.finance/swap) | comprehensive DeFi platform for token swaps, lending, NFT trading, collateralization | 🚩 **dead** ([GitHub](https://github.com/Fairyswap)) | 🚩 | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
+| [Shade Cash](https://shade.cash) | A decentralized protocol for private transactions on Fantom Opera | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | 🚩 | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
 
 # Post-assesment breakdown
 
@@ -63,8 +64,8 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
-| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
-| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | live | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
+| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
 
 **total**: 2 projects
 
@@ -75,15 +76,15 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
-| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
-| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023) | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
-| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
-| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
+| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
+| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | 🚧 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
+| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
+| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | 🚧 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
+| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | 🚧 | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | 🚧 | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
+| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | 🚩 | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
+| [Fairy](https://fairyswap.finance/swap) | 🚩 **dead** ([GitHub](https://github.com/Fairyswap)) | 🚩 | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
 
 **total**: 9 projects
 
@@ -96,17 +97,17 @@
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
 | [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
-| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
-| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta |  anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
-| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
-| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
-| [Hinkal](https://hinkal.pro) | - | mainnet | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
+| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | 🚧 | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | live | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
+| [Light Shield](https://shield.lightprotocol.com) |  - | live |  anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | 🚧 | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
+| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | live | ([anon](https://particl.io/)) | - | - | 50% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | - | 🚩 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
+| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | 🚧 | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
+| [Hinkal](https://hinkal.pro) | - | live | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
 | [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
-| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
-| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
+| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | 🚧 | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
+| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | 🚧 | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
 
 **total**: 12 projects
 
@@ -118,15 +119,15 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
-| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 25% |
-| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
-| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022  | anon | [Docs](https://docs.aztec.network) | - |  25% |
-| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 25% |
-| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | anon | - | - | 25% |
-| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | - | 25% |
-| [Spiral Finance](https://www.spiralfi.io) | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | - | 🚩 | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
+| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live | ([anon](https://offshift.io/#team)) | - | - | 25% |
+| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live | anon | - | - | 25% |
+| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | 🚩  | anon | [Docs](https://docs.aztec.network) | - |  25% |
+| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | 🚩 | anon | - | - | 25% |
+| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | 🚧 | anon | - | - | 25% |
+| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | 🚧 | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | 🚧 | anon | - | - | 25% |
+| [Spiral Finance](https://www.spiralfi.io) | - | 🚧 | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
 
 **total**: 9 projects
 
@@ -138,12 +139,12 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
-| [Silent protocol](https://www.silentprotocol.org)  | - | TBD | Ethereum | anon | - | - | 0% |
-| [Common](https://common.fi) | - | coming in 2023 | Near, Ethereum, Solana, Kusama, Azero | anon | - | - | 0% |
-| [CIA protocol](https://ciaprotocol.com) | - | TBD | Ethereum | anon | - | - | 0% |
-| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | - | multichain | anon | - | - | 0% |
-| [Seven Seas](https://www.sevenseas.exchange) | - | - | - | - | - | - | - | 0% |
-| [NonKYC](https://nonkyc.io) | - | - | - | - | - | - | - | 0% |
+| [Silent protocol](https://www.silentprotocol.org)  | - | 🚧 | anon | - | - | 0% |
+| [Common](https://common.fi) | - | 🚧 | anon | - | - | 0% |
+| [CIA protocol](https://ciaprotocol.com) | - | 🚧 | Ethereum | anon | - | - | 0% |
+| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | 🚩 | anon | - | - | 0% |
+| [Seven Seas](https://www.sevenseas.exchange) | - | 🚧 | - | - | - | - | - | 0% |
+| [NonKYC](https://nonkyc.io) | - | 🚧 | - | - | - | - | - | 0% |
 
 **total**: 6 projects
 
@@ -161,7 +162,7 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
 
 **total**: 1 project
 
@@ -169,11 +170,11 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- | ------------ | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 75% |
+| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | 🚧 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
+| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | 🚧 | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | 🚧 | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
+| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | live | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 75% |
 
 **total**: 5 projects
 
@@ -184,14 +185,14 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
-| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
-| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
-| [Hinkal](https://hinkal.pro) | - | mainnet | Polygon | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
+| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | 🚧 | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
+| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | 🚧 | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | 🚧 | ([anon](https://particl.io/)) | - | - | 50% |
+| [Hinkal](https://hinkal.pro) | - | live | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
 | [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
-| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 50% |
-| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 50% |
-| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 50% |
+| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 50% |
+| [Fairy](https://fairyswap.finance/swap) | 🚩 **dead** ([GitHub](https://github.com/Fairyswap)) | 🚩 | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 50% |
+| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 50% |
 
 **total**: 8 projects
 
@@ -202,13 +203,13 @@
 
 | Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
 | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
-| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | 25% |
-| [Spiral Finance](https://www.spiralfi.io) | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 25% |
-| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 25% |
-| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 25% |
-| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 25% |
+| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | 🚧 | anon | - | 25% |
+| [Spiral Finance](https://www.spiralfi.io) | - | 🚧 | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | 🚧 | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 25% |
+| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | live | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 25% |
+| [Light Shield](https://shield.lightprotocol.com) |  - | mlive | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 25% |
+| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | 🚧 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 25% |
 
 **total**: 7 projects
 
@@ -219,23 +220,23 @@
 
 | Project  | GitHub | Product-readiness |  Team | Docs | Audit | Score |
 | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
-| [Silent protocol](https://www.silentprotocol.org)  | - | TBD | anon | - | - | 0% |
-| [Common](https://common.fi) | - | coming in 2023 | anon | - | - | 0% |
-| [CIA protocol](https://ciaprotocol.com) | - | TBD | anon | - | - | 0% |
-| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | - | anon | - | - | 0% |
-| [Seven Seas](https://www.sevenseas.exchange) | - | - | - | - | - | - | 0% |
-| [NonKYC](https://nonkyc.io) | - | - | - | - | - | - | 0% |
-| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | anon | [Docs](https://docs.aztec.network) | - |  0% |
+| [Silent protocol](https://www.silentprotocol.org)  | - | 🚧 | anon | - | - | 0% |
+| [Common](https://common.fi) | - | 🚧 | anon | - | - | 0% |
+| [CIA protocol](https://ciaprotocol.com) | - | 🚧 | anon | - | - | 0% |
+| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | 🚧 | anon | - | - | 0% |
+| [Seven Seas](https://www.sevenseas.exchange) | - | 🚧 | - | - | - | - | 0% |
+| [NonKYC](https://nonkyc.io) | - | 🚧 | - | - | - | - | 0% |
+| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | 🚩 | anon | [Docs](https://docs.aztec.network) | - |  0% |
 | 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 0% |
 | [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | anon | - | - | 0% |
 | [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 0% |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 0%  |
-| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 0%  |
-| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 0% |
-| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 0% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 0% |
-| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 0% |
-| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | - | 🚩 | anon | ([Docs](https://docs.xata.fi)) | - | 0%  |
+| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live | ([anon](https://offshift.io/#team)) | - | - | 0%  |
+| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | 🚧 | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 0% |
+| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | 🚧 | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 0% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | - | 🚩 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 0% |
+| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | 🚩 | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 0% |
+| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | 🚩 | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
 
 **total**: 17 projects
 

--- a/Web3privacynowplatform/scoringmodel/DeFi category prototype.md
+++ b/Web3privacynowplatform/scoringmodel/DeFi category prototype.md
@@ -16,55 +16,55 @@
 
 ## DeFi
 ![alt text](https://github.com/Msiusko/web3privacy/blob/main/static-assets/DEFI.png?raw=true)
-| Project  | Description | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | Firn is the first-ever zero-knowledge privacy platform in the _account-based_ model, and introduces pluggable, flexible privacy to Ethereum-based chains. ✨️**ZK** | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | Ethereum | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Shade](https://shadeprotocol.io)  | Shade Protocol is an array of connected privacy-preserving DeFi applications built on Secret Network  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | Cosmos | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
-| [Silent protocol](https://www.silentprotocol.org)  | Silent Protocol is the first protocol enabling compliant full-stack privacy for smart contract assets and web3 applications at scale.  | - | TBD | Ethereum | anon | - | - | 0% |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | A MEV Minimization solution to survive the Dark Forest  | - | TBD | Automata | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
-| [Sienna Network](https://sienna.network) | Sienna is a privacy-first and cross-chain decentralized finance platform where you can privately swap, lend and convert your tokens into their private equivalent  | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | Secret Network | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
-| [Elusiv](https://elusiv.io) | Create blockchain privacy solutions that are built for everyday transactions — with the power of scalable ZK infrastructure on Solana ✨️**ZK** | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | Solana | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
-| [Offshift](https://www.offshift.io) | Offshift’s proprietary Shifting mechanism allows users to Shift between our native token, XFT, and a full palette of private synthetics | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | Ethereum | ([anon](https://offshift.io/#team)) | - | - | 25% |
-| [CAPE](https://www.espressosys.com/product) | Configurable Asset Privacy for Ethereum | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | Ethereum | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Evanesco](https://evanesco.org) | A financial protocol platform that combines Layer0 network infrastructure with a private computing framework. | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | Eva | anon | - | - | 25% |
-| [Dusk Network](https://dusk.network) | Is technology for securities. An open source and secure blockchain (DLT) infrastructure that businesses use to tokenize financial instruments and automate costly processes. | ([GitHub](https://github.com/dusk-network)) | testnet | Dusk | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
-| [Manta Pay](https://app.manta.network/dolphin/transact) | MantaPay is coming to Calamari as the first privacy payment solution in the Kusama ecosystem.✨️**ZK**  | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | Polkadot | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | an interoperable private bridge ✨️**ZK** | ([GitHub](https://github.com/webb-tools)) | beta | Tangle | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Panther Protocol](https://www.pantherprotocol.io) | is a decentralized privacy metaprotocol enabling confidential, trusted transactions and interoperability with DeFi ✨️**ZK** | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | Ethereum, Elrond, Polkadot, Avalanche, Near, Flare | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
-| 🚩 **sunset** [zk.money](https://zk.money) | The private DeFi yield aggregator for Ethereum.✨️**ZK** | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | Ethereum | anon | [Docs](https://docs.aztec.network) | - |  25% |
-| [RAILGUN](https://railgun.org) | Private transfers and DeFi infra for Ethereum, Polygon, Binance Smart Chain and Arbitrum.✨️**ZK** | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | Ethereum, BNB, Polygon | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
-| [Umbra](https://app.umbra.cash) |  As a protocol, Umbra defines a simple set of standards, coupled with a singleton smart contract instance, to enable stealth addresses on Ethereum | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | Ethereum | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
-| [Light Shield](https://shield.lightprotocol.com) |  private transactions for Solana. | - | mainnet-beta | Solana  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | Decentralized Anonymous Payment Systems ✨️**ZK** | - | TBD | - | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
+| Project  | Description | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- | ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [Firn Protocol](https://app.firn.cash) | Firn is the first-ever zero-knowledge privacy platform in the _account-based_ model, and introduces pluggable, flexible privacy to Ethereum-based chains. ✨️**ZK** | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Shade](https://shadeprotocol.io)  | Shade Protocol is an array of connected privacy-preserving DeFi applications built on Secret Network  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
+| [Silent protocol](https://www.silentprotocol.org)  | Silent Protocol is the first protocol enabling compliant full-stack privacy for smart contract assets and web3 applications at scale.  | - | TBD | anon | - | - | 0% |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | A MEV Minimization solution to survive the Dark Forest  | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
+| [Sienna Network](https://sienna.network) | Sienna is a privacy-first and cross-chain decentralized finance platform where you can privately swap, lend and convert your tokens into their private equivalent  | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
+| [Elusiv](https://elusiv.io) | Create blockchain privacy solutions that are built for everyday transactions — with the power of scalable ZK infrastructure on Solana ✨️**ZK** | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
+| [Offshift](https://www.offshift.io) | Offshift’s proprietary Shifting mechanism allows users to Shift between our native token, XFT, and a full palette of private synthetics | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 25% |
+| [CAPE](https://www.espressosys.com/product) | Configurable Asset Privacy for Ethereum | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
+| [Evanesco](https://evanesco.org) | A financial protocol platform that combines Layer0 network infrastructure with a private computing framework. | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
+| [Dusk Network](https://dusk.network) | Is technology for securities. An open source and secure blockchain (DLT) infrastructure that businesses use to tokenize financial instruments and automate costly processes. | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [Manta Pay](https://app.manta.network/dolphin/transact) | MantaPay is coming to Calamari as the first privacy payment solution in the Kusama ecosystem.✨️**ZK**  | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
+| [Webb](https://app.webb.tools/#/tornado) | an interoperable private bridge ✨️**ZK** | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Panther Protocol](https://www.pantherprotocol.io) | is a decentralized privacy metaprotocol enabling confidential, trusted transactions and interoperability with DeFi ✨️**ZK** | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
+| 🚩 **sunset** [zk.money](https://zk.money) | The private DeFi yield aggregator for Ethereum.✨️**ZK** | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | anon | [Docs](https://docs.aztec.network) | - |  25% |
+| [RAILGUN](https://railgun.org) | Private transfers and DeFi infra for Ethereum, Polygon, Binance Smart Chain and Arbitrum.✨️**ZK** | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| [Umbra](https://app.umbra.cash) |  As a protocol, Umbra defines a simple set of standards, coupled with a singleton smart contract instance, to enable stealth addresses on Ethereum | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
+| [Light Shield](https://shield.lightprotocol.com) |  private transactions for Solana. | - | mainnet-beta  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | Decentralized Anonymous Payment Systems ✨️**ZK** | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
 | [Diva](https://www.diva.exchange/en/) | Free banking technology for everyone: everyone can join in, everyone can use DIVA.EXCHANGE | ([GitHub](https://github.com/diva-exchange)) | TBD | - | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | the first and only multichain dApp to offer plug-and-play private DeFi (PriFi) across all EVM-compatible chains | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | EVM compatible | anon | - | - | 25% |
-| [BasicSwap](https://basicswapdex.com) | Private Cross-Chain DEX | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | SMSG | ([anon](https://particl.io/)) | - | - | 50% |
-| [Common](https://common.fi) | Common will be a decentralized exchange that mitigates the Maximal Extractable Value (MEV) problem. | - | coming in 2023 | Near, Ethereum, Solana, Kusama, Azero | anon | - | - | 0% |
+| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | the first and only multichain dApp to offer plug-and-play private DeFi (PriFi) across all EVM-compatible chains | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 25% |
+| [BasicSwap](https://basicswapdex.com) | Private Cross-Chain DEX | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
+| [Common](https://common.fi) | Common will be a decentralized exchange that mitigates the Maximal Extractable Value (MEV) problem. | - | coming in 2023 | anon | - | - | 0% |
 | [Sacred](https://sacred.finance) |  multi-chain DeFi Platform offers private Yield Bearing Deposits to DeFi users ✨️**ZK* | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | Ethereum, Polygon | anon | - | - | 25% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | The first dedicated privacy protocol ecosystem that enables on-platform trade between volatile and stable assets | - | coming in 2023 | Ethereum, BNB, Polygon, Solana, Avalanche | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | The first dedicated privacy protocol ecosystem that enables on-platform trade between volatile and stable assets | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
 | 🚩 **sunset** [DeFiner](https://definer.org) | Permission-less and configurable decentralized lending protocol with privacy 100% protected ✨️**ZK** | ([GitHub](https://github.com/DeFinerOrg)) | beta | DeFiner | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
-| [Hurricane Protocol](https://hurricane.money) | A fully decentralized protocol offering private transactions on both the Terra & NEAR | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | Terra, Near | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
-| [StealthPay](https://www.stealthpay.cash) | a stealth address protocol for Ethereum.| 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | Ethereum | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | collection of tools allowing you send & receive SCRT anonymously | ([GitHub](https://github.com/TriviumNode)) | TBD | Secret Network | anon | - | - | 25% |
+| [Hurricane Protocol](https://hurricane.money) | A fully decentralized protocol offering private transactions on both the Terra & NEAR | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
+| [StealthPay](https://www.stealthpay.cash) | a stealth address protocol for Ethereum.| 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | collection of tools allowing you send & receive SCRT anonymously | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | - | 25% |
 | [Hinkal](https://hinkal.pro) | an easy-to-integrate privacy SDK that helps users anonymize transactions.  | - | mainnet | Polygon | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
-| [Conceal Network](https://conceal.network) | privacy-protected DeFi & encrypted comms | ([GitHub](https://github.com/ConcealNetwork)) | live | Conceal | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
-| [CIA protocol](https://ciaprotocol.com) | Building the truest form of DeFi with privacy by default. | - | TBD | Ethereum | anon | - | - | 0% |
-| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | Decentralized Multi Chain P2P Order Book | - | - | multichain | anon | - | - | 0% |
-| [Seven Seas](https://www.sevenseas.exchange) | No KYC, privacy Focused crypto Exchange | - | - | - | - | - | - | - | 0% |
-| [NonKYC](https://nonkyc.io) | NonKYC Exchange | - | - | - | - | - | - | - | 0% |
-| [zkUSD](https://zkusd.money/#Features) | Privacy-Preserving Collateralized Lending & more | 🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
-| [Spiral Finance](https://www.spiralfi.io) | non-custodial privacy solution based on ZK-Sync ERA ✨️**ZK** | - | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
-| [Fairy](https://fairyswap.finance/swap) | comprehensive DeFi platform for token swaps, lending, NFT trading, collateralization | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
-| [Shade Cash](https://shade.cash) | A decentralized protocol for private transactions on Fantom Opera | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
+| [Conceal Network](https://conceal.network) | privacy-protected DeFi & encrypted comms | ([GitHub](https://github.com/ConcealNetwork)) | Live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
+| [CIA protocol](https://ciaprotocol.com) | Building the truest form of DeFi with privacy by default. | - | TBD | anon | - | - | 0% |
+| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | Decentralized Multi Chain P2P Order Book | - | - | anon | - | - | 0% |
+| [Seven Seas](https://www.sevenseas.exchange) | No KYC, privacy Focused crypto Exchange | - | - | - | - | - | - | 0% |
+| [NonKYC](https://nonkyc.io) | NonKYC Exchange | - | - | - | - | - | - | 0% |
+| [zkUSD](https://zkusd.money/#Features) | Privacy-Preserving Collateralized Lending & more | 🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
+| [Spiral Finance](https://www.spiralfi.io) | non-custodial privacy solution based on ZK-Sync ERA ✨️**ZK** | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| [Fairy](https://fairyswap.finance/swap) | comprehensive DeFi platform for token swaps, lending, NFT trading, collateralization | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
+| [Shade Cash](https://shade.cash) | A decentralized protocol for private transactions on Fantom Opera | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
 
 # Post-assesment breakdown
 
 ## 100% scoring
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | Ethereum, Elrond, Polkadot, Avalanche, Near, Flare | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
-| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | Ethereum, BNB, Polygon | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
+| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 100% |
+| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
 
 **total**: 2 projects
 
@@ -73,17 +73,17 @@
 
 ## 75% scoring
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | Ethereum | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | Cosmos | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
-| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | Secret Network | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
-| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | Solana | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
-| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | Polkadot | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | Tangle | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | - | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | DeFiner | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
-| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 75% |
+| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 75% |
+| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023) | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 75% |
+| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
+| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
+| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
+| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 75% |
 
 **total**: 9 projects
 
@@ -93,18 +93,18 @@
 
 ## 50% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | Ethereum | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | Dusk | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
-| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | Ethereum | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
-| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta | Solana  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | - | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
-| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | SMSG | ([anon](https://particl.io/)) | - | - | 50% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | Ethereum, BNB, Polygon, Solana, Avalanche | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
-| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | Terra, Near | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
-| [Hinkal](https://hinkal.pro) | - | mainnet | Polygon | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
-| [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | Conceal | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
+| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 50% |
+| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta |  anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 50% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 50% |
+| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 50% |
+| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 50% |
+| [Hinkal](https://hinkal.pro) | - | mainnet | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
+| [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
 | [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 50% |
 | [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 50% |
 
@@ -116,17 +116,17 @@
 
 ## 25% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | Automata | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
-| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | Ethereum | ([anon](https://offshift.io/#team)) | - | - | 25% |
-| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | Eva | anon | - | - | 25% |
-| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | Ethereum | anon | [Docs](https://docs.aztec.network) | - |  25% |
-| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | EVM compatible | anon | - | - | 25% |
-| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | Ethereum, Polygon | anon | - | - | 25% |
-| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | Ethereum | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | Secret Network | anon | - | - | 25% |
-| [Spiral Finance](https://www.spiralfi.io) | - | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 25% |
+| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 25% |
+| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
+| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022  | anon | [Docs](https://docs.aztec.network) | - |  25% |
+| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 25% |
+| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | anon | - | - | 25% |
+| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | - | 25% |
+| [Spiral Finance](https://www.spiralfi.io) | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
 
 **total**: 9 projects
 
@@ -136,8 +136,8 @@
 
 ## 0% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- |------------- | ------------- | ------------- | ------------- |
 | [Silent protocol](https://www.silentprotocol.org)  | - | TBD | Ethereum | anon | - | - | 0% |
 | [Common](https://common.fi) | - | coming in 2023 | Near, Ethereum, Solana, Kusama, Azero | anon | - | - | 0% |
 | [CIA protocol](https://ciaprotocol.com) | - | TBD | Ethereum | anon | - | - | 0% |
@@ -159,21 +159,21 @@
 
 ## 100% scoring
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | Ethereum, BNB, Polygon | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| [RAILGUN](https://railgun.org) | [Github](https://github.com/Railgun-Community) | live, Jul 2021 | ([Public](https://railgun.org/#/contributors)) | [Docs](https://docs.railgun.org/developer-guide/cookbook/cookbook-overview) | [5 audits](https://assets.railgun.org/docs/audits/) | 100% |  
 
 **total**: 1 project
 
 ## 75% scoring
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | Ethereum | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
-| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | Polkadot | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
-| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | Tangle | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
-| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | - | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
-| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | Ethereum, Elrond, Polkadot, Avalanche, Near, Flare | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 75% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- | ------------ | ------------- | ------------- | ------------- | ------------- |
+| [Firn Protocol](https://app.firn.cash) | ([GitHub](https://github.com/firnprotocol)) | live, june 2022 | anon | [Docs](https://docs.firn.cash) | [BlockSec](https://github.com/blocksecteam/audit-reports/blob/main/solidity/blocksec_firnprotocol_v1.0-signed.pdf) | 75% |
+| [Manta Pay](https://app.manta.network/dolphin/transact) | ([GitHub](https://github.com/Manta-Network)) | testnet v3 | public | [Docs](https://docs.manta.network/docs/Introduction) | - | 75% |
+| [Webb](https://app.webb.tools/#/tornado) | ([GitHub](https://github.com/webb-tools)) | beta | anon | [Docs](https://docs.webb.tools/docs/) | [Audit of the DKG-Substrate pallet](https://blog.webb.tools/webbs-evm-bridge-security-audit-completed-by-veridise/) | 75% |
+| [Diva](https://www.diva.exchange/en/) | ([GitHub](https://github.com/diva-exchange)) | TBD | ([Public](https://www.diva.exchange/en/team-and-contact/)) | [Docs](https://docs.lightprotocol.com) | - | - | 75% |
+| [Panther Protocol](https://www.pantherprotocol.io) | ([GitHub](https://github.com/pantherprotocol))  | testnet launch Q2 2023, mainnet launch Q3 2023 | ([Public](https://www.pantherprotocol.io/)) | [Docs](https://docs.pantherprotocol.io/docs/start-here/panther-protocol-documentation) | 🚩 2021: [ZKP Vesting](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Vesting.pdf), [ZKP Token](https://www.pantherprotocol.io/resources/REP-Panther-ZKP-Token.pdf) | 75% |
 
 **total**: 5 projects
 
@@ -182,16 +182,16 @@
 
 ## 50% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | Ethereum | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
-| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | Dusk | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
-| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | SMSG | ([anon](https://particl.io/)) | - | - | 50% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [CAPE](https://www.espressosys.com/product) | ([GitHub](https://github.com/EspressoSystems/cape)) | testnet | anon | [Docs](https://docs.espressosys.com/sequencer/espresso-sequencer-architecture/readme) | - | 50% |
+| [Dusk Network](https://dusk.network) | ([GitHub](https://github.com/dusk-network)) | testnet | ([Public](https://dusk.network/pages/team)) | - | - | 50% |
+| [BasicSwap](https://basicswapdex.com) | ([GitHub](https://github.com/tecnovert/basicswap/blob/master/doc/install.md)) | beta, December 2022 | ([anon](https://particl.io/)) | - | - | 50% |
 | [Hinkal](https://hinkal.pro) | - | mainnet | Polygon | ([Public](https://hinkal.pro/#section-team)) | - | [Competitive security](https://github.com/Secure3Audit/Secure3Academy/blob/main/audit_reports/Hinkal/Hinkal_final_Secure3_Audit_Report.pdf) | 50% |
-| [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | Conceal | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
-| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | Solana | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 50% |
-| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 50% |
-| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | Cosmos | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 50% |
+| [Conceal Network](https://conceal.network) | ([GitHub](https://github.com/ConcealNetwork)) | live | ([anon](https://conceal.network/team/)) | [Docs](https://conceal.network/wiki/doku.php) | - | 50% |
+| [Elusiv](https://elusiv.io) | ([GitHub](https://github.com/elusiv-privacy)) | live, march 2023 | ([Public](https://www.linkedin.com/search/results/people/?currentCompany=%5B%2280778213%22%5D&origin=COMPANY_PAGE_CANNED_SEARCH&sid=s_%40)) | 🚩 **marketing** [Docs](https://docs.elusiv.io/) | - | 50% |
+| [Fairy](https://fairyswap.finance/swap) | **dead** ([GitHub](https://github.com/Fairyswap)) | - | - | [Docs](https://fairy-swap.gitbook.io/fairyswap-v2/getting-started/about-fairyswap-v2) | 🚩 2022: [Certik](https://skynet.certik.com/projects/fairyswap) | 50% |
+| [Shade](https://shadeprotocol.io)  | ([GitHub](https://github.com/securesecrets/shade)) | live, february 2023 | anon | [Docs](https://docs.shadeprotocol.io/shade-protocol/) | 🚩 2022: [2 audits](https://docs.shadeprotocol.io/shade-protocol/research/audit-log) | 50% |
 
 **total**: 8 projects
 
@@ -200,15 +200,15 @@
 
 ## 25% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | Eva | anon | - | - | 25% |
-| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | Secret Network | anon | - | - | 25% |
-| [Spiral Finance](https://www.spiralfi.io) | - | - | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
-| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | - | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 25% |
-| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | Ethereum | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 25% |
-| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta | Solana  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 25% |
-| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | Secret Network | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 25% |
+| Project  | GitHub | Product-readiness | Team | Docs | Audit | Score |
+| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [Evanesco](https://evanesco.org) | ([GitHub](https://github.com/Evanesco-Labs)) | live, december 2021 | anon | - | - | 25% |
+| [BlackBox](https://blackbox.cash) | ([GitHub](https://github.com/TriviumNode)) | TBD | anon | - | 25% |
+| [Spiral Finance](https://www.spiralfi.io) | - | - | ([Docs](https://docs.spiralfi.io/introduction/spiral-finance)) | - | 25% |
+| [Horizon](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | - | TBD | anon | 🚩 **marketing** [Docs](https://messier.gitbook.io/catalogue-de-messier/messier-applications/horizon) | [Messier](https://skynet.certik.com/projects/messier) | 25% |
+| [Umbra](https://app.umbra.cash) | ([GitHub](https://github.com/ScopeLift/umbra-protocol)) | mainnet, june 2021 | anon | - | 🚩 2021: [3 audits](https://app.umbra.cash/faq#security) | 25% |
+| [Light Shield](https://shield.lightprotocol.com) |  - | mainnet-beta  | anon | [Docs](https://docs.lightprotocol.com) | 🚩 2022: [Code review](https://github.com/Lightprotocol/light-protocol-v1/blob/main/Audit/Light%20Protocol%20Audit%20Report.pdf) | 25% |
+| [Sienna Network](https://sienna.network) | 🚩`LOW` ([GitHub](https://github.com/SiennaNetwork)) | Q2 2023 | anon | [Docs](https://docs.sienna.network/main/) | 🚩 2022: [9 audits](https://sienna.network/audits/) | 25% |
 
 **total**: 7 projects
 
@@ -217,25 +217,25 @@
 
 ## 0% scoring 
 
-| Project  | GitHub | Product-readiness | Ecosystem | Team | Docs | Audit | Score |
-| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [Silent protocol](https://www.silentprotocol.org)  | - | TBD | Ethereum | anon | - | - | 0% |
-| [Common](https://common.fi) | - | coming in 2023 | Near, Ethereum, Solana, Kusama, Azero | anon | - | - | 0% |
-| [CIA protocol](https://ciaprotocol.com) | - | TBD | Ethereum | anon | - | - | 0% |
-| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | - | multichain | anon | - | - | 0% |
-| [Seven Seas](https://www.sevenseas.exchange) | - | - | - | - | - | - | - | 0% |
-| [NonKYC](https://nonkyc.io) | - | - | - | - | - | - | - | 0% |
-| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | Ethereum | anon | [Docs](https://docs.aztec.network) | - |  0% |
-| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | EVM compatible | anon | - | - | 0% |
-| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | Ethereum, Polygon | anon | - | - | 0% |
-| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | Ethereum | anon | - | - | 0% |
-| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | Automata | anon | ([Docs](https://docs.xata.fi)) | - | 0%  |
-| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | Ethereum | ([anon](https://offshift.io/#team)) | - | - | 0%  |
-| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 0% |
-| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 0% |
-| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | Ethereum, BNB, Polygon, Solana, Avalanche | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 0% |
-| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | Terra, Near | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 0% |
-| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | DeFiner | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
+| Project  | GitHub | Product-readiness |  Team | Docs | Audit | Score |
+| ------------- |------------- |------------- | ------------- | ------------- | ------------- | ------------- |
+| [Silent protocol](https://www.silentprotocol.org)  | - | TBD | anon | - | - | 0% |
+| [Common](https://common.fi) | - | coming in 2023 | anon | - | - | 0% |
+| [CIA protocol](https://ciaprotocol.com) | - | TBD | anon | - | - | 0% |
+| 🚩 **sunset** [CoinBook](https://www.coinbook.app) | - | - | anon | - | - | 0% |
+| [Seven Seas](https://www.sevenseas.exchange) | - | - | - | - | - | - | 0% |
+| [NonKYC](https://nonkyc.io) | - | - | - | - | - | - | 0% |
+| 🚩 **sunset** [zk.money](https://zk.money) | ([Docs](https://docs.aztec.network/zk-money/userguide)) | live, july 2022 | anon | [Docs](https://docs.aztec.network) | - |  0% |
+| 🚩 **sunset** [Yellow Submarine](https://ys.finance) | ([Docs](https://yellow-s.gitbook.io/docs/ys-basics/introduction)) | TBD | anon | - | - | 0% |
+| [Sacred](https://sacred.finance) | 🚩 **LOW** ([GitHub](https://github.com/Sacred-Finance)) | TBD | anon | - | - | 0% |
+| [StealthPay](https://www.stealthpay.cash) | 🚩 **dead** ([GitHub](https://github.com/cryptoadong)) | TBD | anon | - | - | 0% |
+| 🚩 **sunset** [XATA](https://www.xata.fi) | - | TBD | anon | ([Docs](https://docs.xata.fi)) | - | 0%  |
+| [Offshift](https://www.offshift.io) | 🚩 **LOW** ([GitLab](https://open.offshift.io/offshiftXFT)) | live, march 2023 | ([anon](https://offshift.io/#team)) | - | - | 0%  |
+| [zkUSD](https://zkusd.money/#Features) |  🚩 **no code** ([GitHub](https://github.com/zkUSDLabs)) | - | - | 🚩 **marketing** [Docs](https://zkusd.gitbook.io/zkusd-documentation) | - | 0% |
+| [Shade Cash](https://shade.cash) | 🚩 **no code** ([GitHub](https://github.com/ShadeCash)) | - | - | 🚩 **marketing** [Docs](https://shadecash.gitbook.io/shadecash) | - | 0% |
+| 🚩 **sunset** [Sahara](https://sahara.network) | - | coming in 2023 | ([Public](https://sahara.network/)) | - | 🚩 2022: [Vesting contract](https://sahara.network/resources/sahara-security-audit.pdf) | 0% |
+| [Hurricane Protocol](https://hurricane.money) | 🚩 **no code** ([GitHub](https://github.com/Hurricane-Protocol)) | TBD | anon | 🚩 **marketing** [Docs](https://docs.hurricane.money) | - | 0% |
+| 🚩 **sunset** [DeFiner](https://definer.org) | ([GitHub](https://github.com/DeFinerOrg)) | beta | anon | [Docs](https://docs.definer.org) | 🚩 2020: [Savings audits](https://docs.definer.org/v/copy-of-definer.org/security/audits) | 75% |
 
 **total**: 17 projects
 


### PR DESCRIPTION
This 2nd PR has the changes to the DeFi category prototype.md included (see previous PR)

I cleaned it up a bit more (missed a few ecosystem entries) and added the 🚧 

**Proposa** 
Making 'Product-readiness' a binary option with either 'live' or 🚧 placed in that cell of the tables. 

To be discussed if (as noted in .md) the absence of live in this cell would mean an exclusion and a score of 0% for that project.

A project can have 75% score because of the other criteria but not be live on a mainnet would mean people might YOLO into a beta product or protocol - this scoring will be read by non-techies