### PR TITLE
Updated ALTER network listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Feel free to update the list!
 | [Waku](https://waku.org) | Waku is the communication layer for Web3. Decentralized communication that scales | ([GitHub](https://github.com/waku-org)) | - | - | - |
 | [Status](https://status.im) | Status is a secure messaging app, crypto wallet, and Web3 browser built with state of the art technology | ([GitHub](https://github.com/status-im/)) | - | - | - |
 | [xx messenger](https://elixxir.io) | An ultra-private messaging app, powered by the quantum-resistant and decentralized xx network | ([GitHub](https://git.xx.network/elixxir/client-android)) | - | - | - |
-| [ALTER](https://altermail.co) | Private & Secure Communication App Utilizing Secret Nework's secret contract technology. | - | - | - | - |
+| [ALTER](https://alter.network/) | Private & Secure Communication App Utilizing Secret Nework's secret contract technology - formerly known as Altermail. | n/a | live | multichain | known (LinkedIn) |
 | [Session](https://getsession.org) | An end-to-end encrypted messenger that minimises sensitive metadata, designed and built for people who want absolute privacy and freedom from any form of surveillance. | [GitHub](https://github.com/oxen-io) | Live | Cryptonote | [Public](https://www.linkedin.com/company/sessionmessenger/people/) |
 | [BCchat](https://bchat.beldex.io) | A decentralized, privacy messenger built over the Beldex blockchain. | - | - | - | - |
 | [Crypviser Secure Messenger](https://crypviser.network/) | The most private messaging app, based on Blockchain technology. | - | - | - | - |


### PR DESCRIPTION
Altermail rebranded to ALTER some time in 2022. Updated and added details to the listing in readme.md

*Proof*
Old url linked here https://altermail.co is broken, their Medium blog is hosted on https://blog.altermail.live - but the main domain altermail.live force redirects to https://alter.network