### PR TITLE
Add pado

### DIFF
--- a/Market overview/Ethereum Ecosystem/Readme.md
+++ b/Market overview/Ethereum Ecosystem/Readme.md
@@ -7,26 +7,33 @@ _Here we track all Ethereum privacy related projects, research & events (based o
 2. Adding new positions like EIP-7503
 
 ## Contents
-- [DeFi](#DeFi)
-- [Currency](#Currency)
-- [Infrastructure](#Infrastructure)
-- [Wallet](#Wallet)
-- [Computing network](#Computing-network)
-- [Layer 2](#Layer-2)
-- [Hardware](#Hardware)
-- [DID](#DID)
-- [DAO](#DAO)
-- [Bridge](#Bridge)
-- [Messaging](#Messaging)
-- [Browser](#Browser)
-- [KYC](#KYC)
-- [RPC](#RPC)
-- [Storage](#Storage)
-- [dApps](#dApps) 
-- [NFT](#NFT)
-- [Other](#Other)
-- [Mixing services](#Mixing-services)
-- [Papers](#Papers)
+- [Main dataset of Ethereum Privacy Ecosystem report](#main-dataset-of-ethereum-privacy-ecosystem-report)
+  - [Current phase: Ethereum Privacy DB aggregation](#current-phase-ethereum-privacy-db-aggregation)
+  - [Contents](#contents)
+  - [DeFi](#defi)
+  - [Currency](#currency)
+  - [Infrastructure](#infrastructure)
+  - [Wallet](#wallet)
+  - [Computing network](#computing-network)
+  - [Layer 2](#layer-2)
+  - [Hardware](#hardware)
+  - [DID](#did)
+  - [DAO](#dao)
+  - [Bridge](#bridge)
+  - [Messaging](#messaging)
+  - [Browser](#browser)
+  - [KYC](#kyc)
+  - [RPC](#rpc)
+  - [Storage](#storage)
+  - [dApps](#dapps)
+  - [NFT](#nft)
+  - [R\&D](#rd)
+  - [Node](#node)
+  - [Mixing services](#mixing-services)
+  - [Other](#other)
+  - [Events](#events)
+  - [Network state](#network-state)
+  - [Papers](#papers)
 
 ## DeFi
 ![alt text](https://github.com/Msiusko/web3privacy/blob/main/static-assets/DEFI.png?raw=true)
@@ -111,6 +118,7 @@ _Here we track all Ethereum privacy related projects, research & events (based o
 | [Ampere Chain](https://amperechain.com) | Experience the next generation of D-QBFT. Pioneering EVM, privacy nodes, & unmatched efficiency.  | ([GitHub](https://github.com/AmpereChain)) | - | - | - |
 | [inDEX](https://index.phala.network) | Cross-Chain Intent Infrastructure  | ([GitHub](https://github.com/Phala-Network/index-contract)) | - | - | - |
 | [Insider Protocol](https://insiderprotocol.com/) | Cross-Chain Intent Infrastructure  | - | - | - | - |
+| [PADO](https://padolabs.org/)|Decentralized zkAttestation and Computation Network Powered by Interactive ZKP and zkFHE|([Github](https://github.com/pado-labs))| - | - | - |
 
 ## Wallet
 ![alt text](https://github.com/Msiusko/web3privacy/blob/main/static-assets/Wallet.png?raw=true)

--- a/Market overview/Ethereum Ecosystem/Readme.md
+++ b/Market overview/Ethereum Ecosystem/Readme.md
@@ -442,3 +442,4 @@ _Here we track all Ethereum privacy related projects, research & events (based o
 - [Blockchain Privacy and Regulatory Compliance: Towards a Practical Equilibrium](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4563364)
 - [EIP-7503: Zero-Knowledge Wormholes](https://eips.ethereum.org/EIPS/eip-7503)
 - [Derecho: Privacy Pools with Proof-Carrying Disclosures](https://eprint.iacr.org/2023/273)
+- [Lightweight Authentication of Web Data via Garble-Then-Prove](https://eprint.iacr.org/2023/964)


### PR DESCRIPTION
- Add PADO to the market overview.
- PADO is a zkAttestation and computation network powered by IZK and zkFHE. 
- PADO is also a grantee of PSE contributing interactive zero-knowledge proofs to the [mpz](https://github.com/privacy-scaling-explorations/mpz) library.
- Here is the [whitepaper](https://eprint.iacr.org/2023/964).