### PR TITLE
Fix Typos across multiple documentation files

### DIFF
--- a/Market overview/Ethereum Ecosystem/Readme.md
+++ b/Market overview/Ethereum Ecosystem/Readme.md
@@ -256,7 +256,7 @@ Segmentation will help to split "native" projects & broader actors serving diffe
 | ------------- | ------------- |------------- |------------- | ------------- | ------------- |
 | [Waku](https://waku.org) | Waku is the communication layer for Web3. Decentralized communication that scales | ([GitHub](https://github.com/waku-org)) | - | - | - |
 | [Status](https://status.im) | Status is a secure messaging app, crypto wallet, and Web3 browser built with state of the art technology | ([GitHub](https://github.com/status-im/)) | - | - | - |
-| [Senging.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
+| [Sending.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
 | [RLN Anonymous Chat](https://github.com/njofce/zk-chat) | A spam resistant instant messaging application for private and anonymous communication. | - | - | - | - |
 | [Mejhool](https://hzmcoin.com/mejhool/) | a Decentralized web and mobile app with peer-to-peer text messaging, decentralized file transfer and voice-over-IP service.| - | - | - | - |
 | [DeChat](https://www.dechat.io) | an open, secure web3 communications protocol that powers decentralized user interactions | ([GitBook](https://dechat.gitbook.io/dechat/)) | - | - | - |

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Feel free to contribute to this database via forking and submitting a PR via Git
 | [BCchat](https://bchat.beldex.io) | A decentralized, privacy messenger built over the Beldex blockchain. | - | - | - | - |
 | [XMTP x Lens](https://blog.xmtp.com/lens-dms-with-xmtp) | Lens Protocol has adopted XMTP to provide a secure and private direct messaging layer for the entire Lens ecosystem | [XMTP GitHub](https://github.com/ephemeraHQ/lenster) | mainnet | - | - |
 | [XMTP web3 social](https://xmtp.org/docs/use-cases/deso) | Lens Protocol and CyberConnect apps use XMTP to provide secure, private messaging to their users. | [XMPT Labs Github](https://github.com/ephemeraHQ) | mainnet | - |
-| [Senging.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
+| [Sending.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
 | [Zion](https://www.zion.fyi) | The safest way to join, chat and send | [Github](https://github.com/getzion/) | - | - | - |
 | [RLN Anonymous Chat](https://github.com/njofce/zk-chat) | A spam resistant instant messaging application for private and anonymous communication. | - | - | - | - |
 | [Beepo](https://beepoapp.net) | a social networking application integrated with a multichain chain crypto wallet, a web 3 browser, instant messaging and calling, an eCommerce store, and a sales catalog section for business accounts | [Github](https://github.com/beepo-app) | live | multichain | - |

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Feel free to contribute to this database via forking and submitting a PR via Git
 | [Mullvad Browser](https://github.com/mullvad/mullvad-browser) | The Mullvad Browser is a privacy-focused web browser developed in a collaboration between Mullvad VPN and the Tor Project. | [Github](https://github.com/mullvad/mullvad-browser) | - | - | - |
 | [Fulldive](https://www.fulldive.com) | web3 browser that respects your privacy | - | - | - | - |
 | [Broearn](https://www.broearn.com) | web3 browser that respects your privacy | - | - | - | - |
-| [Solak](https://solak.app) |  Broswer with in-app AI  | - | - | - | - |
+| [Solak](https://solak.app) |  Browser with in-app AI  | - | - | - | - |
 
 ## KYC
 ![alt text](https://github.com/Msiusko/web3privacy/blob/main/static-assets/KYC.png?raw=true)

--- a/Web3privacynowplatform/Scoringmodel.md
+++ b/Web3privacynowplatform/Scoringmodel.md
@@ -224,7 +224,7 @@ _Sketches what could be put inside privacy-solutions scoring model_ (note: think
 - **GitHub repos**: # of commits, # stars, date of repo creation.
 
 **Third-party validation**
-- **Security audits**: yes, no; type of audit; ammount of audits.
+- **Security audits**: yes, no; type of audit; amount of audits.
 
 **Community validation**
 - Existing bugs

--- a/Web3privacynowplatform/scoringmodel/Framework_update.md
+++ b/Web3privacynowplatform/scoringmodel/Framework_update.md
@@ -29,7 +29,7 @@
 **How to use (Extended)**
 | Project | GitHub | Product-readiness | Team | Docs | Audit | Contributors | Licenses | Support | Score |
 | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| **Test project** | 1. Exist. 2. Active (last 6 months). 3. Lots of commits (not fake). | 1. Live (main-net, Beta). | Public team | 1. Exist. 2. Dev-centric. | 1. Exist. 2. Up to date (last 6 months). 3. Complex. | External contributors | Open-source licenses in use | Availbale | from 0 to 100% |
+| **Test project** | 1. Exist. 2. Active (last 6 months). 3. Lots of commits (not fake). | 1. Live (main-net, Beta). | Public team | 1. Exist. 2. Dev-centric. | 1. Exist. 2. Up to date (last 6 months). 3. Complex. | External contributors | Open-source licenses in use | Available | from 0 to 100% |
 | **score** | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% | 12.5% | 100% |
 
 ## **Red flag examples**

--- a/Web3privacynowplatform/scoringmodel/Survey/Readme.md
+++ b/Web3privacynowplatform/scoringmodel/Survey/Readme.md
@@ -125,7 +125,7 @@ Answers
 
 _Observations_
 - general web3 101 is needed for a person to self-check privacy (what is 0zk address, relayer, etherscan etc)
-- simple instructions on transaction traceability will help to self-check sender-receiver-token-ammount links. Input & observations criteria (possible framework?) will help here (short instruction).
+- simple instructions on transaction traceability will help to self-check sender-receiver-token-amount links. Input & observations criteria (possible framework?) will help here (short instruction).
 
 _Product feature_
 - transaction traceability 101 (the basics on Etherscan example)

--- a/only-entries.md
+++ b/only-entries.md
@@ -373,7 +373,7 @@ This md file contains only the entries in table form from the README.md as of 28
 | [BCchat](https://bchat.beldex.io) | A decentralized, privacy messenger built over the Beldex blockchain. | - | - | - | - |
 | [XMTP x Lens](https://blog.xmtp.com/lens-dms-with-xmtp) | Lens Protocol has adopted XMTP to provide a secure and private direct messaging layer for the entire Lens ecosystem | [XMTP GitHub](https://github.com/ephemeraHQ/lenster) | mainnet | - | - |
 | [XMTP web3 social](https://xmtp.org/docs/use-cases/deso) | Lens Protocol and CyberConnect apps use XMTP to provide secure, private messaging to their users. | [XMPT Labs Github](https://github.com/ephemeraHQ) | mainnet | - |
-| [Senging.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
+| [Sending.me](https://sending.me) | open-source communication & social platform. | - | - | - | - |
 | [Zion](https://www.zion.fyi) | The safest way to join, chat and send | [Github](https://github.com/getzion/) | - | - | - |
 | [RLN Anonymous Chat](https://github.com/njofce/zk-chat) | A spam resistant instant messaging application for private and anonymous communication. | - | - | - | - |
 | [Beepo](https://beepoapp.net) | a social networking application integrated with a multichain chain crypto wallet, a web 3 browser, instant messaging and calling, an eCommerce store, and a sales catalog section for business accounts | [Github](https://github.com/beepo-app) | live | multichain | - |

--- a/only-entries.md
+++ b/only-entries.md
@@ -405,7 +405,7 @@ This md file contains only the entries in table form from the README.md as of 28
 | [Mullvad Browser](https://github.com/mullvad/mullvad-browser) | The Mullvad Browser is a privacy-focused web browser developed in a collaboration between Mullvad VPN and the Tor Project. | [Github](https://github.com/mullvad/mullvad-browser) | - | - | - |
 | [Fulldive](https://www.fulldive.com) | web3 browser that respects your privacy | - | - | - | - |
 | [Broearn](https://www.broearn.com) | web3 browser that respects your privacy | - | - | - | - |
-| [Solak](https://solak.app) |  Broswer with in-app AI  | - | - | - | - |
+| [Solak](https://solak.app) |  Browser with in-app AI  | - | - | - | - |
 
 ## KYC
 | Project  | Description | GitHub | Product-readiness | Ecosystem | Team |


### PR DESCRIPTION
Several documentation files contained minor spelling errors, including but not limited to:
- "Senging.me" instead of "Sending.me"
- "Broswer" instead of "Browser"
- "ammount" instead of "amount"
- "Availbale" instead of "Available"
