### PR TITLE
docs: Fix spelling errors in Web3 Privacy Now briefs

### DIFF
--- a/Web3privacynowplatform/Briefs/Brief 2.0.md
+++ b/Web3privacynowplatform/Briefs/Brief 2.0.md
@@ -84,7 +84,7 @@ How it works:
 | **Privacy policy** | add link |
 | **Collected data**  | specify what data do you collect |
 | **Data sharing** | specify what data you share with third-parties |
-| **Sign-in requirments** | specify what data is needed to start using service |
+| **Sign-in requirements** | specify what data is needed to start using service |
 | **Identity integrations** | do you use third-party identity services (like ENS, Gitcoin Passport etc) |
 
 **Security**

--- a/Web3privacynowplatform/Briefs/Brume.md
+++ b/Web3privacynowplatform/Briefs/Brume.md
@@ -76,7 +76,7 @@ How it works:
 | **Privacy policy** | no |
 | **Collected data**  | opt-in: public anonymous debugging logs |
 | **Data sharing** | no |
-| **Sign-in requirments** | none |
+| **Sign-in requirements** | none |
 | **Identity integrations** | ENS |
 
 **Security**

--- a/Web3privacynowplatform/Briefs/Fileverse.md
+++ b/Web3privacynowplatform/Briefs/Fileverse.md
@@ -74,7 +74,7 @@ How it works:
 | **Privacy policy** | add link |
 | **Collected data**  | specify what data do you collect |
 | **Data sharing** | specify what data you share with third-parties |
-| **Sign-in requirments** | specify what data is needed to start using service |
+| **Sign-in requirements** | specify what data is needed to start using service |
 | **Identity integrations** | do you use third-party identity services (like ENS, Gitcoin Passport etc) |
 
 **Security**

--- a/Web3privacynowplatform/Briefs/Railgun.md
+++ b/Web3privacynowplatform/Briefs/Railgun.md
@@ -63,7 +63,7 @@ How it works:
 | **Technical specialisation**  | ZK, Smart Contract | 
 | **Specify technology readiness**  | infra: mainnet, apps: full production | 
 | **Features**  | list 3 key tech features | 
-| **Encryption method**  | if aplicable: specify | 
+| **Encryption method**  | if applicable: specify | 
 
 **Privacy**
 | Request  | Data point | 
@@ -74,7 +74,7 @@ How it works:
 | **Privacy policy** | add link |
 | **Collected data**  | none |
 | **Data sharing** | none |
-| **Sign-in requirments** | none |
+| **Sign-in requirements** | none |
 | **Identity integrations** | Users can link their ENS and Unstoppable Domains to their private 0zk address. There is no privacy degredation from this. |
 
 **Security**


### PR DESCRIPTION
Corrected "requirments" → "requirements" in multiple briefs (Brief 2.0, Brume, Fileverse, Railgun).

Fixed typo "aplicable" → "applicable" in Railgun brief.